### PR TITLE
Don't establish DB connections accidentally when checking for open txns

### DIFF
--- a/lib/ar_after_transaction.rb
+++ b/lib/ar_after_transaction.rb
@@ -52,6 +52,8 @@ module ARAfterTransaction
     private
 
     def transactions_open?
+      pool = connection_pool
+      return false unless pool && pool.active_connection?
       connection.open_transactions > normally_open_transactions
     end
 

--- a/spec/ar_after_transaction_spec.rb
+++ b/spec/ar_after_transaction_spec.rb
@@ -119,6 +119,19 @@ describe ARAfterTransaction do
     User.test_stack.should == [:normal, :normal]
   end
 
+  it "does not establish a DB connection when one isn't already active for the current thread" do
+    executed = false
+    expect(User.connection_pool).not_to receive(:checkout)
+
+    Thread.new {
+      User.after_transaction do
+        executed = true
+      end
+    }.join
+
+    expect(executed).to be true
+  end
+
   it "does not crash with additional options" do
     User.transaction(:requires_new => true){}
   end


### PR DESCRIPTION
## Summary

This change ensures that `#transactions_open?` won't accidentally establish new DB connections just to ask them if they have any open transactions.

## Detailed Context

We're using `ar_after_transaction` in combination with a Resque `around_enqueue` hook to ensure that our Resque jobs don't get enqueued if the transaction that triggered them ends up being rolled back.

We also happen to use `resque-scheduler`, which allows you to enqueue jobs periodically according to a cron-style schedule. These enqueues each happen in a throwaway thread spawned just for the purpose of doing the enqueue, and they also hit our `around_enqueue` hook.

This means that when resque-scheduler goes to enqueue a periodic job, it ends up calling `ActiveRecord::Base.after_transaction`, which eventually calls down into `ARAfterTransaction::ClassMethods#transactions_open?`, which calls `connection.open_transactions` to check the number of open transactions.

When this happens in a thread that doesn't yet have an associated DB connection, the call to `#connection` winds up creating a *new* connection just for the purpose of asking it the number of `open_transactions` that it has, which is always going to be zero.

With this change, we'll first ask the pool whether there's an active connection for the current thread, and only do the transaction count check if the answer is yes.