### PR TITLE
Make the gem warning free on Ruby 2.7

### DIFF
--- a/lib/ar_after_transaction.rb
+++ b/lib/ar_after_transaction.rb
@@ -12,9 +12,9 @@ module ARAfterTransaction
       end
     end
 
-    def transaction_with_after(*args)
+    def transaction_with_after(**args)
       clean = true
-      transaction_without_after(*args) do
+      transaction_without_after(**args) do
         begin
           yield
         rescue ActiveRecord::Rollback


### PR DESCRIPTION
This PR removes the warnings that are present from when Rails calls its
`transaction` method, since this gem overrides that method. These
warnings are:

```
vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.3.2/lib/active_record/transactions.rb:211:
warning: The called method `transaction_without_after' is defined here
vendor/bundle/ruby/2.7.0/gems/ar_after_transaction-0.6.0/lib/ar_after_transaction.rb:17:
warning: Using the last argument as keyword parameters is deprecated;
maybe ** should be added to the call
```

The method `transaction` accepts keyword arguments (or a `Hash` in
older Rails versions), therefore we need to separate the keyword
arguments from the positional arguments.

---

I did this PR as small as I could - let me know if you want me to update
the build matrix with the Ruby version etc. I tested this against our
app on Ruby 2.7 and nothing obvious broke.