### PR TITLE
Fix readme: normally_open_transactions doesn't get set

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,11 +54,12 @@ after_transaction will perform the given block immediately
 after_transaction assumes zero open transactions.<br/>
 If you use transactional fixtures you should change it in test mode.
 
+`Rspec:`
 ```ruby
-# config/environments/test.rb
-config.after_initialize do
-  ActiveRecord::Base.normally_open_transactions = 1
-end
+# spec/rails_helper.rb
+  config.before(:suite) do
+    ActiveRecord::Base.normally_open_transactions = 1
+  end
 ```
 
 ### Rails 3: after_commit hook can replace the first usage example:


### PR DESCRIPTION
Hi,

The update to 0.7 caused our tests to stop passing.

It turned out that 655b4cd98a79ea288791be4eb9f3dd376bfd7e95 changed the behaviour of `normally_open_transactions=` and it cannot be used correctly in `test.rb` anymore. 

We managed to fix this in our project, by assigning the correct value in the RSpec hook. Would like to share the solution as others might experience it.

Best,
Adam