### PR TITLE
Update test matrix gemfiles to use valid mimemagic versions

### DIFF
--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_after_transaction (0.6.1)
+    ar_after_transaction (0.7.0)
       activerecord (>= 4.2.0, < 6.2)
 
 GEM
@@ -67,7 +67,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -146,4 +148,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.2.3
+   2.3.4

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_after_transaction (0.6.1)
+    ar_after_transaction (0.7.0)
       activerecord (>= 4.2.0, < 6.2)
 
 GEM
@@ -80,7 +80,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -162,4 +164,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.17.3
+   2.3.4

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    ar_after_transaction (0.6.1)
+    ar_after_transaction (0.7.0)
       activerecord (>= 4.2.0, < 6.2)
 
 GEM
@@ -84,7 +84,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -165,4 +167,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   2.2.3
+   2.3.4


### PR DESCRIPTION
As seen on [rubygems.org](https://rubygems.org/gems/mimemagic/versions), most older versions of mimemagic have been yanked. This updates the relevant test matrix gemfiles to use a valid mimemagic version.