### PR TITLE
Rescue from Exception, not just StandardError

### DIFF
--- a/lib/ar_after_transaction.rb
+++ b/lib/ar_after_transaction.rb
@@ -48,7 +48,7 @@ module ARAfterTransactionConnection
       clean = false
       raise
     end
-  rescue StandardError
+  rescue Exception
     clean = false
     raise
   ensure


### PR DESCRIPTION
## Problem

We had a container with a long-running Resque job, where the job's logic was wrapped in a transaction and we had various `after_transaction` blocks. The job wound up going unhealthy, so our infrastructure signaled the container to spin down with a `SIGTERM`, which turns into a `SignalException` in the Ruby process. The container exited, but we found that the `after_transaction` callbacks were still firing unexpectedly!

Rails will `rescue Exception` to roll back the transaction then re-raise the error. Latest source as of this writing: https://github.com/rails/rails/blob/c8c95f424eba7cb5f69c06d25db6eb21dc60bdb0/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L539-L543 (note that it's `rescue Exception` in older versions of Rails, as well).

However, ar_after_transaction is currently only rescuing `StandardError` to flag `clean = false`. Without rescuing from `Exception`, `clean` remains `true`, meaning the `ensure` block will proceed with the callbacks.

Thus, the `after_transaction` callbacks still wind up firing on `Exception` (the `SignalException`, in our case), even though the transaction itself gets aborted by Rails. It looks like this behavior changed (inadvertently?) with a rewrite in 655b4cd98a79ea288791be4eb9f3dd376bfd7e95, where `rescue Exception` became `rescue StandardError`.

## Solution

This PR rescues from `Exception` instead of just `StandardError`, and adds a test that reproduces the `SignalException` flow we were seeing in production. I verified that the test fails when the code uses `rescue StandardError`, and it passes locally with the proposed fix.

The change should be safe, given:
1. Rails does a similar `rescue Exception`, so this gives ar_after_transaction parity with the Rails behavior
2. Rails & ar_after_transaction both re-raise the error regardless, so we aren't swallowing anything (just making sure to set `clean = false` accurately)